### PR TITLE
include has option to not silently fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ import (
     "text/template"
 
     "github.com/Masterminds/sprig/v3"
-    "github.com/bluebrown/treasure-map/textfunc"
+    "github.com/mlabbe/treasure-map/textfunc"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bluebrown/treasure-map
+module github.com/mlabbe/treasure-map
 
 go 1.18
 

--- a/textfunc/closure.go
+++ b/textfunc/closure.go
@@ -2,13 +2,20 @@ package textfunc
 
 import (
 	"bytes"
+	"fmt"
+	"os"
 	"text/template"
 )
 
-func MakeInclude(t *template.Template) func(string, any) string {
+func MakeInclude(t *template.Template, fatalIfError bool) func(string, any) string {
 	return func(name string, v any) string {
 		b := new(bytes.Buffer)
 		if err := t.ExecuteTemplate(b, name, v); err != nil {
+			if fatalIfError {
+				fmt.Fprintf(os.Stderr, "Error including named template: '%s':\n%s\n", name, err)
+				os.Exit(1)
+			}
+
 			return ""
 		}
 		return b.String()

--- a/textfunc/funcmap.go
+++ b/textfunc/funcmap.go
@@ -23,9 +23,9 @@ func Map() map[string]any {
 
 }
 
-func MapClosure(baseMap map[string]any, t *template.Template) map[string]any {
+func MapClosure(baseMap map[string]any, t *template.Template, fatalIfMissing bool) map[string]any {
 	funcMap := Register(baseMap)
-	funcMap["include"] = MakeInclude(t)
+	funcMap["include"] = MakeInclude(t, fatalIfMissing)
 	funcMap["tpl"] = MakeTpl(t)
 	return funcMap
 }

--- a/textfunc/textfunc_test.go
+++ b/textfunc/textfunc_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/bluebrown/treasure-map/textfunc"
+	"github.com/mlabbe/treasure-map/textfunc"
 )
 
 func TestMapClosure(t *testing.T) {


### PR DESCRIPTION
Pass fatalIfMissing true in to MapClosure()

This prevents silent failure when include fails to work. This prevents unknown downstream results from affecting the user.